### PR TITLE
Adding stop's own info to /proximity JSON output

### DIFF
--- a/models/stop.rb
+++ b/models/stop.rb
@@ -64,13 +64,12 @@ class Stop
     end
 
     @proximal = {
-   								 'id' => @code,
-   								 'name' => @name,
-   								 'lat' => @coords.lat,
-   								 'lon' => @coords.lon,
-   								 'proximals' => @@proximals[@stop_id]
-   								}
-#    @proximal << @@proximals[@stop_id]
+                  'id' => @code,
+                  'name' => @name,
+                  'lat' => @coords.lat,
+                  'lon' => @coords.lon,
+                  'proximals' => @@proximals[@stop_id]
+                }
   end
 
   STOP_INFO_URI = 'http://api.pugetsound.onebusaway.org/api/where/stop/%s.json?key=%s'

--- a/models/stop.rb
+++ b/models/stop.rb
@@ -63,7 +63,14 @@ class Stop
       @@proximals[@stop_id] << result
     end
 
-    @proximal = @@proximals[@stop_id]
+    @proximal = {
+   								 'id' => @code,
+   								 'name' => @name,
+   								 'lat' => @coords.lat,
+   								 'lon' => @coords.lon,
+   								 'proximals' => @@proximals[@stop_id]
+   								}
+#    @proximal << @@proximals[@stop_id]
   end
 
   STOP_INFO_URI = 'http://api.pugetsound.onebusaway.org/api/where/stop/%s.json?key=%s'


### PR DESCRIPTION
I'm not sure I should be doing much with this backend if it's going to get replaced, but I do need to be able to get the kiosk's own coordinates to implement maps in a flexible way, and this seems like the easiest way to expose those.

I don't plan to keep making tiny pull requests like this!  I think this is all the prep work I need to do, and the next increment should be actually adding basic maps to the kiosk display.